### PR TITLE
BrowserWindows - Automates the Browser Windows feature on DemoQA

### DIFF
--- a/cypress/e2e/frontend/browser_windows/browser_windows.feature
+++ b/cypress/e2e/frontend/browser_windows/browser_windows.feature
@@ -1,0 +1,10 @@
+Feature: Browser Windows
+
+  Scenario: Open a new browser window and validate content
+    Given the DemoQA website is open
+    When the "Alerts, Frame & Windows" section is accessed
+    And the main menu submenu "Browser Windows" is clicked
+    And the "New Window" button is clicked
+    Then a new window should be opened
+    And the new window should display the text "This is a sample page"
+    And the new window is closed

--- a/cypress/support/step_definitions/frontend/browser_windows/browser_windows.step.js
+++ b/cypress/support/step_definitions/frontend/browser_windows/browser_windows.step.js
@@ -1,0 +1,43 @@
+import { Given, When, Then } from "@badeball/cypress-cucumber-preprocessor";
+
+Given("the DemoQA website is open", () => {
+  cy.visit("/");
+});
+
+When('the {string} section is accessed', (section) => {
+  cy.contains(section).scrollIntoView().click({ force: true });
+});
+
+When('the main menu submenu {string} is clicked', (submenu) => {
+  cy.contains(submenu).scrollIntoView().click({ force: true });
+});
+
+When('the {string} button is clicked', (button) => {
+  cy.url().then((originalUrl) => {
+    cy.window().then((win) => {
+      cy.stub(win, 'open').callsFake((url) => {
+        cy.visit(url);
+      }).as("popup");
+    });
+
+    cy.contains('button', button).scrollIntoView().click({ force: true });
+
+    cy.get("@popup").should("be.called");
+
+    cy.contains('This is a sample page', { timeout: 10000 }).should('be.visible');
+
+    cy.visit(originalUrl);
+  });
+});
+
+Then("a new window should be opened", () => {
+  cy.url().should('include', 'sample');
+});
+
+Then('the new window should display the text {string}', (text) => {
+  cy.contains(text).should('be.visible');
+});
+
+Then('the new window is closed', () => {
+  cy.go('back');
+});


### PR DESCRIPTION
Opens the new window in the same tab and validates the content. 
Cypress does not support multiple browser windows, so the popup is opened in the same tab and "closed" by navigating back to the original page.
