### PR TITLE
ProgressBar: Automate Progress Bar widget interaction

### DIFF
--- a/cypress/e2e/frontend/progress_bar/progress_bar.feature
+++ b/cypress/e2e/frontend/progress_bar/progress_bar.feature
@@ -10,6 +10,6 @@ Scenario: Start, stop at 25%, complete, and reset the progress bar
     And the "Start" button is clicked
     And the progress bar is stopped before reaching 25%
     Then the progress bar value should be less than or equal to 25%
-    When the "Start" button is clicked again
+    When the "Start" button is clicked
     And the progress bar reaches 100%
     Then the progress bar is reset

--- a/cypress/support/step_definitions/common/common.steps.js
+++ b/cypress/support/step_definitions/common/common.steps.js
@@ -1,7 +1,7 @@
 import { Given, When, Before } from "@badeball/cypress-cucumber-preprocessor";
 
 Before(() => {
-  cy.viewport(1380, 720); // garante resolução fixa
+  cy.viewport(1380, 720);
 });
 
 Given("the DemoQA website is open", () => {
@@ -14,4 +14,22 @@ When('the {string} section is accessed', (section) => {
 
 When('the {string} submenu is clicked', (submenu) => {
   cy.contains(submenu).click();
+});
+
+When('the {string} button is clicked', (button) => {
+  if (button === 'Start') {
+    cy.get('#startStopButton').click();
+    
+  } else {
+    cy.contains('button', button).scrollIntoView().click({ force: true });
+    cy.url().then(() => {
+    cy.window().then((win) => {
+      cy.stub(win, 'open').callsFake((url) => {
+        cy.visit(url);
+      }).as("popup");
+    });
+
+    cy.contains('button', button).scrollIntoView().click({ force: true });
+  });
+  }
 });

--- a/cypress/support/step_definitions/frontend/browser_windows/browser_windows.step.js
+++ b/cypress/support/step_definitions/frontend/browser_windows/browser_windows.step.js
@@ -1,27 +1,7 @@
-import { Given, When, Then } from "@badeball/cypress-cucumber-preprocessor";
+import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
 
-// Given("the DemoQA website is open", () => {
-//   cy.visit("/");
-// });
-
-// When('the {string} section is accessed', (section) => {
-//   cy.contains(section).scrollIntoView().click({ force: true });
-// });
-var url = '';
 When('the main menu submenu {string} is clicked', (submenu) => {
   cy.contains(submenu).scrollIntoView().click({ force: true });
-});
-
-When('the {string} button is clicked', (button) => {
-  cy.url().then((originalUrl) => {
-    cy.window().then((win) => {
-      cy.stub(win, 'open').callsFake((url) => {
-        cy.visit(url);
-      }).as("popup");
-    });
-
-    cy.contains('button', button).scrollIntoView().click({ force: true });
-  });
 });
 
 Then("a new window should be opened", () => {


### PR DESCRIPTION
This PR adds automation for the Progress Bar widget on DemoQA. 
It covers starting the progress bar, stopping before 25%, validating the value, 
continuing to 100%, and resetting the progress bar. 
Cypress and Cucumber steps are implemented in third person for clarity.
